### PR TITLE
FIX: eager loading necessary relationships and add hydrate method

### DIFF
--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -689,6 +689,11 @@ class Chat extends Component
         $this->loadMessages();
     }
 
+    public function hydrate()
+    {
+        $this->loadMessages();
+    }
+
     private function initializeConversation()
     {
         abort_unless(auth()->check(), 401);
@@ -706,7 +711,7 @@ class Chat extends Component
     {
         if (in_array($this->conversation->type, [ConversationType::PRIVATE, ConversationType::SELF])) {
             $this->conversation->load('participants');
-            $participants = $this->conversation->participants;
+            $participants = $this->conversation->participants()->with('participantable', 'conversation')->get();
 
             $this->authParticipant = $participants
                 ->where('participantable_id', auth()->id())

--- a/src/Livewire/Chat/Chats.php
+++ b/src/Livewire/Chat/Chats.php
@@ -83,6 +83,7 @@ class Chats extends Component
                 // 'lastMessage' ,//=> fn($query) => $query->select('id', 'sendable_id','sendable_type', 'created_at'),
                 'messages',
                 'lastMessage.attachment',
+                'lastMessage.sendable',
                 'receiver.participantable',
                 'group.cover', //=> fn($query) => $query->select('id', 'name'),
 


### PR DESCRIPTION
### before it was causing this errors when lazy loading is disabled:

---

**when loading an one on one chat:**
```diff
- Attempted to lazy load [participantable] on model [Namu\WireChat\Models\Participant] but lazy loading is disabled.
```
**fixed by changing this on** `Chat.php`:
```php
$participants = $this->conversation->participants()->with('participantable')->get();
```

---

**after sending a message on any conversation:**
```diff
- Attempted to lazy load [parent] on model [Namu\WireChat\Models\Message] but lazy loading is disabled.
```
**fixed by adding this on** `Chat.php`:
```php
public function hydrate()
{
    $this->loadMessages();
}
```

---

**Steps to reproduce before closing the PR:**
* add `Model::shouldBeStrict();` in 'boot()' method on `AppServiceProviders.php`