### PR TITLE
Fix/replace receiver participant with peer participant

### DIFF
--- a/resources/views/livewire/chat/group/permissions.blade.php
+++ b/resources/views/livewire/chat/group/permissions.blade.php
@@ -12,7 +12,7 @@
     <div class="">
         <section >
 
-            <h5 class="w-full text-start py-4 bg-gray-50 dark:bg-gray-950 px-50 px-4">
+            <h5 class="w-full text-start py-4 bg-gray-50 dark:bg-gray-950 px-4">
                 
                 {{__('wirechat::chat.group.permisssions.labels.members_can')}}:
             </h5>

--- a/resources/views/livewire/chats/partials/list.blade.php
+++ b/resources/views/livewire/chats/partials/list.blade.php
@@ -6,11 +6,11 @@
     @php
     //$receiver =$conversation->getReceiver();
     $group = $conversation->isGroup() ? $conversation->group : null;
-    $receiver = $conversation->isGroup() ? null : ($conversation->isPrivate() ? $conversation->receiverParticipant?->participantable : $this->auth);
+    $receiver = $conversation->isGroup() ? null : ($conversation->isPrivate() ? $conversation->peer_participant?->participantable : $this->auth);
     //$receiver = $conversation->isGroup() ? null : ($conversation->isPrivate() ? $conversation->peerParticipant()?->participantable : $this->auth);
     $lastMessage = $conversation->lastMessage;
     //mark isReadByAuth true if user has chat opened
-    $isReadByAuth = $conversation?->readBy($conversation->authParticipant??$this->auth) || $selectedConversationId == $conversation->id;
+    $isReadByAuth = $conversation?->readBy($conversation->auth_participant??$this->auth) || $selectedConversationId == $conversation->id;
     $belongsToAuth = $lastMessage?->belongsToAuth();
 
 

--- a/resources/views/livewire/new/group.blade.php
+++ b/resources/views/livewire/new/group.blade.php
@@ -66,9 +66,9 @@
                 </header>
 
                 <main class="my-5">
-                    <div class=" my-auto space-y-2">
+                    <div class=" my-auto flex flex-col gap-y-2">
 
-                        <label for="description">@lang('wirechat::new.group.inputs.description.label')</label>
+                        <label class="my-2" for="description">@lang('wirechat::new.group.inputs.description.label')</label>
 
                         <textarea id='description' type="text" wire:model='description' placeholder="{{__('wirechat::new.group.inputs.description.placeholder')}}" rows="4"
                             class=" w-full resize-none rounded-lg border-gray-200 focus:border-gray-200 dark:border-gray-700   bg-inherit dark:text-white outline-hidden w-full focus:outline-hidden  focus:ring-0 hover:ring-0">

--- a/src/Events/NotifyParticipant.php
+++ b/src/Events/NotifyParticipant.php
@@ -40,9 +40,6 @@ class NotifyParticipant implements ShouldBroadcastNow
 
         $message->load('conversation.group', 'sendable', 'attachment');
 
-        // dd($message->conversation->isPrivate());
-        //  Log::info(['message Resource from NotifyParticipant'=> (new MessageResource($this->message))]);
-
     }
 
     /**
@@ -57,8 +54,6 @@ class NotifyParticipant implements ShouldBroadcastNow
     {
         // Check if the message is not older than 60 seconds
         $isNotExpired = Carbon::parse($this->message->created_at)->gt(Carbon::now()->subMinute(1));
-
-        //  Log::info(['NotifyParticipant isNotExpired'=>$isNotExpired]);
 
         return $isNotExpired;
     }

--- a/src/Events/NotifyParticipant.php
+++ b/src/Events/NotifyParticipant.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 use Namu\WireChat\Facades\WireChat;
 use Namu\WireChat\Helpers\MorphClassResolver;
 use Namu\WireChat\Http\Resources\MessageResource;

--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -608,14 +608,14 @@ class Chat extends Component
     }
 
     // used to broadcast message sent to receiver
-    protected function dispatchMessageCreatedEvent(Message $message):void
+    protected function dispatchMessageCreatedEvent(Message $message): void
     {
 
         // Dont dispatch if it is a selfConversation
 
         if ($this->conversation->isSelf()) {
 
-            return ;
+            return;
         }
 
         // send broadcast message only to others
@@ -627,14 +627,14 @@ class Chat extends Component
 
             // !remove the receiver from the messageCreated and add it to the job instead
             // !also do not forget to exlude auth user or message owner from particpants
-            // todo: maybe also broadcast for self conversation , incase user is using multiple devices 
+            // todo: maybe also broadcast for self conversation , incase user is using multiple devices
             // sleep(3);
             broadcast(new MessageCreated($message))->toOthers();
 
             // notify participants if conversation is NOT self
-            if (!$this->conversation->isSelf()) {
+            if (! $this->conversation->isSelf()) {
                 NotifyParticipants::dispatch($this->conversation, $message);
-            } 
+            }
         } catch (\Throwable $th) {
 
             Log::error($th->getMessage());

--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -627,6 +627,7 @@ class Chat extends Component
 
             // !remove the receiver from the messageCreated and add it to the job instead
             // !also do not forget to exlude auth user or message owner from particpants
+            // todo: maybe also broadcast for self conversation , incase user is using multiple devices 
             // sleep(3);
             broadcast(new MessageCreated($message))->toOthers();
 
@@ -782,12 +783,12 @@ class Chat extends Component
     private function initializeParticipants()
     {
         if (in_array($this->conversation->type, [ConversationType::PRIVATE, ConversationType::SELF])) {
-            $this->conversation->load('participants');
+            $this->conversation->load('participants.participantable');
             $participants = $this->conversation->participants();
 
             $this->authParticipant = $participants->whereParticipantable($this->auth)->first();
 
-            $this->receiverParticipant = $this->conversation->receiverParticipant;
+            $this->receiverParticipant = $this->conversation->peerParticipant($this->auth);
 
             // If conversation is self then receiver is auth;
             if ($this->conversation->type == ConversationType::SELF) {

--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -608,14 +608,14 @@ class Chat extends Component
     }
 
     // used to broadcast message sent to receiver
-    protected function dispatchMessageCreatedEvent(Message $message)
+    protected function dispatchMessageCreatedEvent(Message $message):void
     {
 
         // Dont dispatch if it is a selfConversation
 
-        if ($this->conversation->isSelfConversation($this->auth)) {
+        if ($this->conversation->isSelf()) {
 
-            return null;
+            return ;
         }
 
         // send broadcast message only to others
@@ -631,22 +631,10 @@ class Chat extends Component
             // sleep(3);
             broadcast(new MessageCreated($message))->toOthers();
 
-            // if conversation is private then Notify particpant immediately
-            if ($this->conversation->isPrivate() || $this->conversation->isSelf()) {
-
-                if ($this->conversation->isPrivate() && $this->receiverParticipant) {
-
-                    //   broadcast(new NotifyParticipant($this->receiverParticipant, $message))->toOthers();
-
-                    // dd('broadcasting');
-                    NotifyParticipants::dispatch($this->conversation, $message);
-                    //    Notification::send($this->receiver, new NewMessageNotification($message));
-
-                }
-            } else {
-                // code...
+            // notify participants if conversation is NOT self
+            if (!$this->conversation->isSelf()) {
                 NotifyParticipants::dispatch($this->conversation, $message);
-            }
+            } 
         } catch (\Throwable $th) {
 
             Log::error($th->getMessage());

--- a/src/Livewire/Chat/Info.php
+++ b/src/Livewire/Chat/Info.php
@@ -68,17 +68,20 @@ class Info extends ModalComponent
 
         abort_if($this->conversation->isGroup(), 403, __('wirechat::chat.info.messages.invalid_conversation_type_error'));
 
+        // load participants
+        $this->conversation->load('participants.participantable');
+
     }
 
     public function render()
     {
 
-        $cover_url = $this->conversation->getReceiver()?->cover_url;
+        $receiver = $this->conversation?->peerParticipant(auth()->user())?->participantable;
 
         // Pass data to the view
         return view('wirechat::livewire.chat.info', [
-            'receiver' => $this->conversation?->getReceiver(),
-            'cover_url' => $cover_url,
+            'receiver' => $receiver,
+            'cover_url' => $receiver?->cover_url,
         ]);
     }
 }

--- a/src/Livewire/Chats/Chats.php
+++ b/src/Livewire/Chats/Chats.php
@@ -191,7 +191,7 @@ class Chats extends Component
     {
         $perPage = 10;
         $offset = ($this->page - 1) * $perPage;
-    
+
         $additionalConversations = $this->auth->conversations()
             ->with([
                 'lastMessage.sendable',
@@ -210,7 +210,7 @@ class Chats extends Component
                 // Manually load participants (only 2 expected in private/self)
                 $participants = $conversation->participants()->select('id', 'participantable_id', 'participantable_type', 'conversation_id', 'conversation_read_at')->with('participantable')->get();
                 $conversation->setRelation('participants', $participants);
-    
+
                 // Set peer and auth participants
                 $conversation->auth_participant = $conversation->participant($this->auth);
                 $conversation->peer_participant = $conversation->peerParticipant($this->auth);
@@ -218,14 +218,14 @@ class Chats extends Component
         });
 
         $this->canLoadMore = $additionalConversations->count() === $perPage;
-    
+
         $this->conversations = collect($this->conversations)
             ->concat($additionalConversations)
             ->unique('id')
             ->sortByDesc('updated_at')
             ->values();
     }
-    
+
     /**
      * Eager loads additional conversation relationships.
      *
@@ -235,23 +235,22 @@ class Chats extends Component
     {
         $this->conversations->map(function ($conversation) {
             // Only load participants manually if not a group
-            if (!$conversation->isGroup()) {
+            if (! $conversation->isGroup()) {
                 $participants = $conversation->participants()->select('id', 'participantable_id', 'participantable_type', 'conversation_id', 'conversation_read_at')->with(['participantable', 'actions'])->get();
-    
+
                 $conversation->setRelation('participants', $participants);
-    
-                  //Set peer and auth participants
-                  $conversation->auth_participant = $conversation->participant($this->auth);
-                  $conversation->peer_participant = $conversation->peerParticipant(reference:$this->auth);
+
+                // Set peer and auth participants
+                $conversation->auth_participant = $conversation->participant($this->auth);
+                $conversation->peer_participant = $conversation->peerParticipant(reference: $this->auth);
             }
-    
+
             return $conversation->loadMissing([
                 'lastMessage',
                 'group.cover' => fn ($query) => $query->select('id', 'url', 'attachable_type', 'attachable_id', 'file_path'),
             ]);
         });
     }
-    
 
     /**
      * Returns the authenticated user.

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -313,7 +313,7 @@ class Conversation extends Model
      * @param  Model  $reference  The reference user/model to exclude.
      * @return Participant|null The other participant or null if not applicable.
      */
-    public function peerParticipant(Model $reference): ?Participant
+    public function peerParticipant(Model|Authenticatable $reference): ?Participant
     {
         // Return null if user does not belong to conversation
         if (! $reference->belongsToConversation($this)) {
@@ -329,12 +329,12 @@ class Conversation extends Model
             ? collect($this->participants) // Convert to collection if already loaded
             : $this->participants()->get(); // Fetch as a collection
 
-        //If is set then return references's participant
+        // If is set then return references's participant
         if ($this->isSelf()) {
             return $participants->where('participantable_id', $reference->id)->where('participantable_type', $reference->getMorphClass())->first();
         }
 
-        //else return participant who is not the reference
+        // else return participant who is not the reference
         return $participants->reject(fn ($participant) => $participant->participantable_id == $reference->id &&
             $participant->participantable_type == $reference->getMorphClass()
         )->first();
@@ -370,6 +370,7 @@ class Conversation extends Model
     /**
      * Get receiver Participant for Private Conversation
      * will return null for Self Conversation
+     *
      * @deprecated
      */
     public function receiverParticipant(): HasOne
@@ -387,6 +388,7 @@ class Conversation extends Model
     /**
      * Get Auth Participant all types Private Conversation
      * will return Auth for Self Conversation
+     *
      * @deprecated
      */
     public function authParticipant(): HasOne

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -329,10 +329,12 @@ class Conversation extends Model
             ? collect($this->participants) // Convert to collection if already loaded
             : $this->participants()->get(); // Fetch as a collection
 
+        //If is set then return references's participant
         if ($this->isSelf()) {
             return $participants->where('participantable_id', $reference->id)->where('participantable_type', $reference->getMorphClass())->first();
         }
 
+        //else return participant who is not the reference
         return $participants->reject(fn ($participant) => $participant->participantable_id == $reference->id &&
             $participant->participantable_type == $reference->getMorphClass()
         )->first();
@@ -368,6 +370,7 @@ class Conversation extends Model
     /**
      * Get receiver Participant for Private Conversation
      * will return null for Self Conversation
+     * @deprecated
      */
     public function receiverParticipant(): HasOne
     {
@@ -384,6 +387,7 @@ class Conversation extends Model
     /**
      * Get Auth Participant all types Private Conversation
      * will return Auth for Self Conversation
+     * @deprecated
      */
     public function authParticipant(): HasOne
     {

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -1317,16 +1317,11 @@ describe('Sending messages ', function () {
         // Queue::fake();
 
         $auth = User::factory()->create();
-        $receiver = User::factory()->create(['name' => 'John']);
-        $conversation = Conversation::factory()
-            ->withParticipants([$auth])
-            ->create();
+        $conversation = $auth->createConversationWith($auth);
 
         Livewire::actingAs($auth)->test(ChatBox::class, ['conversation' => $conversation->id])
             ->set('body', 'New message')
             ->call('sendMessage');
-
-        $message = Message::first();
 
         Queue::assertNotPushed(NotifyParticipants::class);
     });


### PR DESCRIPTION

**Added:**
- `peerParticipant($reference)` method to retrieve the peer participant without relying on the global `auth()`.

**Updated:**
- Replaced usage of `receiverParticipant` scope (which depended on `auth()->user()`) with the new `peerParticipant` approach for better flexibility and testability.
- Refactored `loadConversations()` and `hydrateConversations()` to avoid eager loading all participants in group conversations, improving performance for large group chats.

**Fixed:**
- Issue where conversation hydration required the presence of an authenticated user, causing potential issues in job/event contexts.
