### PR TITLE
fix: "Close Chat" button not working

### DIFF
--- a/resources/views/livewire/chat/partials/header.blade.php
+++ b/resources/views/livewire/chat/partials/header.blade.php
@@ -103,7 +103,7 @@
 
                         @if ($this->isWidget())
                             <x-wirechat::dropdown-link
-                                @click="$dispatch('close-chat',{conversation: @js($conversation->id)})">
+                                @click="$dispatch('close-chat',{conversation: {{ $conversation->id }}})">
                                 @lang('wirechat::chat.actions.close_chat.label')
                             </x-wirechat::dropdown-link>
                         @else


### PR DESCRIPTION
This PR fixes the alpine error:

![image](https://github.com/user-attachments/assets/fae82324-63c5-48ee-b54a-4107a7ecd75d)

Steps to reproduce:

1. From the Chats core component, open a chat
2. The warning is shown in the console about invalid token
3. This button doesn't work:
    
    ![image](https://github.com/user-attachments/assets/c56740f0-e8b1-4a8e-931d-0239f9f31451)
