### PR TITLE
fix: add UUID support to attachments and actions migrations

### DIFF
--- a/database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php
+++ b/database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Wirechat\Wirechat\Facades\Wirechat;
 use Wirechat\Wirechat\Models\Attachment;
 
 return new class extends Migration
@@ -12,10 +13,14 @@ return new class extends Migration
      */
     public function up(): void
     {
-
-        Schema::create((new Attachment)->getTable(), function (Blueprint $table) {
+        $usesUuid = Wirechat::usesUuid();
+        Schema::create((new Attachment)->getTable(), function (Blueprint $table) use ($usesUuid) {
             $table->id();
-            $table->morphs('attachable');
+            if ($usesUuid) {
+                $table->uuidMorphs('attachable');
+            } else {
+                $table->morphs('attachable');
+            }
             $table->string('file_path');
             $table->string('file_name');
             $table->string('original_name');

--- a/database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php
+++ b/database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php
@@ -13,14 +13,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $usesUuid = Wirechat::usesUuid();
-        Schema::create((new Attachment)->getTable(), function (Blueprint $table) use ($usesUuid) {
+        Schema::create((new Attachment)->getTable(), function (Blueprint $table){
             $table->id();
-            if ($usesUuid) {
-                $table->uuidMorphs('attachable');
-            } else {
-                $table->morphs('attachable');
-            }
+            $table->string('attachable_id');
+            $table->string('attachable_type');
             $table->string('file_path');
             $table->string('file_name');
             $table->string('original_name');

--- a/database/migrations/2024_11_01_000006_create_wirechat_actions_table.php
+++ b/database/migrations/2024_11_01_000006_create_wirechat_actions_table.php
@@ -17,21 +17,15 @@ return new class extends Migration
         Schema::create((new Action)->getTable(), function (Blueprint $table) use ($usesUuid) {
             $table->id();
 
+            //Always string for UUID or integer-as-string
             // Actionable (the entity being acted upon)
-            if ($usesUuid) {
-                $table->uuid('actionable_id');
-            } else {
-                $table->unsignedBigInteger('actionable_id');
-            }
-            $table->string('actionable_type');
+           $table->string('actionable_id'); 
+           $table->string('actionable_type');
 
             // Actor (the one performing the action
-            if ($usesUuid) {
-                $table->uuid('actor_id');
-            } else {
-                $table->unsignedBigInteger('actor_id');
-            }
-            $table->string('actor_type');
+           $table->string('actor_id'); 
+           $table->string('actor_type');
+
 
             // Type of action (e.g., delete, archive)
             $table->string('type');

--- a/database/migrations/2024_11_01_000006_create_wirechat_actions_table.php
+++ b/database/migrations/2024_11_01_000006_create_wirechat_actions_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Wirechat\Wirechat\Facades\Wirechat;
 use Wirechat\Wirechat\Models\Action;
 
 return new class extends Migration
@@ -12,16 +13,24 @@ return new class extends Migration
      */
     public function up(): void
     {
-
-        Schema::create((new Action)->getTable(), function (Blueprint $table) {
+        $usesUuid = Wirechat::usesUuid();
+        Schema::create((new Action)->getTable(), function (Blueprint $table) use ($usesUuid) {
             $table->id();
 
             // Actionable (the entity being acted upon)
-            $table->unsignedBigInteger('actionable_id');
+            if ($usesUuid) {
+                $table->uuid('actionable_id');
+            } else {
+                $table->unsignedBigInteger('actionable_id');
+            }
             $table->string('actionable_type');
 
             // Actor (the one performing the action
-            $table->unsignedBigInteger('actor_id');
+            if ($usesUuid) {
+                $table->uuid('actor_id');
+            } else {
+                $table->unsignedBigInteger('actor_id');
+            }
             $table->string('actor_type');
 
             // Type of action (e.g., delete, archive)

--- a/tests/Feature/MigrationsUuidTest.php
+++ b/tests/Feature/MigrationsUuidTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Wirechat\Wirechat\Models\Action;
+use Wirechat\Wirechat\Models\Attachment;
+use Wirechat\Wirechat\Models\Conversation;
+use Wirechat\Wirechat\Models\Group;
+use Wirechat\Wirechat\Models\Message;
+use Wirechat\Wirechat\Models\Participant;
+
+beforeEach(function () {
+    // Drop all tables to ensure clean state
+    Schema::dropIfExists((new Action)->getTable());
+    Schema::dropIfExists((new Attachment)->getTable());
+    Schema::dropIfExists((new Group)->getTable());
+    Schema::dropIfExists((new Participant)->getTable());
+    Schema::dropIfExists((new Message)->getTable());
+    Schema::dropIfExists((new Conversation)->getTable());
+});
+
+/**
+ * Helper to check if a column type matches expected UUID type across different databases
+ */
+function isUuidColumnType(string $type): bool
+{
+    return match (strtolower($type)) {
+        'varchar', 'char', 'uuid', 'character', 'nvarchar', 'uniqueidentifier', 'string' => true,
+        default => false,
+    };
+}
+
+/**
+ * Helper to check if a column type matches expected integer type across different databases
+ */
+function isIntegerColumnType(string $type): bool
+{
+    return match (true) {
+        str_contains(strtolower($type), 'int') => true, // matches int, bigint, integer, etc.
+        default => false,
+    };
+}
+
+describe('UUID configuration in migrations', function () {
+
+    test('conversations table uses UUID when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run the migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000001_create_wirechat_conversations_table.php';
+        $migration->up();
+
+        // Check if id column is UUID type
+        $columnType = Schema::getColumnType((new Conversation)->getTable(), 'id');
+        expect(isUuidColumnType($columnType))->toBeTrue();
+    });
+
+    test('conversations table uses integer when UUID not configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', false);
+
+        // Run the migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000001_create_wirechat_conversations_table.php';
+        $migration->up();
+
+        // Check if id column is integer type
+        $columnType = Schema::getColumnType((new Conversation)->getTable(), 'id');
+        expect(isIntegerColumnType($columnType))->toBeTrue();
+    });
+
+    test('messages table conversation_id uses UUID when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run conversations migration first
+        $convMigration = include __DIR__.'/../../database/migrations/2024_11_01_000001_create_wirechat_conversations_table.php';
+        $convMigration->up();
+
+        // Run messages migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000003_create_wirechat_messages_table.php';
+        $migration->up();
+
+        // Check if conversation_id column is UUID type
+        $columnType = Schema::getColumnType((new Message)->getTable(), 'conversation_id');
+        expect(isUuidColumnType($columnType))->toBeTrue();
+    });
+
+    test('participants table conversation_id uses UUID when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run conversations migration first
+        $convMigration = include __DIR__.'/../../database/migrations/2024_11_01_000001_create_wirechat_conversations_table.php';
+        $convMigration->up();
+
+        // Run participants migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000004_create_wirechat_participants_table.php';
+        $migration->up();
+
+        // Check if conversation_id column is UUID type
+        $columnType = Schema::getColumnType((new Participant)->getTable(), 'conversation_id');
+        expect(isUuidColumnType($columnType))->toBeTrue();
+    });
+
+    test('groups table conversation_id uses UUID when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run conversations migration first (not needed for schema check but good for foreign key)
+        $convMigration = include __DIR__.'/../../database/migrations/2024_11_01_000001_create_wirechat_conversations_table.php';
+        $convMigration->up();
+
+        // Run groups migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000007_create_wirechat_groups_table.php';
+        $migration->up();
+
+        // Check if conversation_id column is UUID type
+        $columnType = Schema::getColumnType((new Group)->getTable(), 'conversation_id');
+        expect(isUuidColumnType($columnType))->toBeTrue();
+    });
+
+    test('attachments table should handle polymorphic UUID references when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run attachments migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php';
+        $migration->up();
+
+        // For polymorphic relationships that could reference UUID models,
+        // the attachable_id should be UUID type
+        $columnType = Schema::getColumnType((new Attachment)->getTable(), 'attachable_id');
+
+        expect(isUuidColumnType($columnType))->toBeTrue();
+    });
+
+    test('actions table should handle polymorphic UUID references when configured', function () {
+        // Set UUID configuration
+        Config::set('wirechat.uuids', true);
+
+        // Run actions migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000006_create_wirechat_actions_table.php';
+        $migration->up();
+
+        // For polymorphic relationships that could reference UUID models (like conversations),
+        // the actionable_id and actor_id should be UUID type
+        $actionableType = Schema::getColumnType((new Action)->getTable(), 'actionable_id');
+        $actorType = Schema::getColumnType((new Action)->getTable(), 'actor_id');
+
+        expect(isUuidColumnType($actionableType))->toBeTrue();
+        expect(isUuidColumnType($actorType))->toBeTrue();
+    });
+});
+
+describe('UUID configuration in migrations with integer IDs', function () {
+
+    test('attachments table uses integer for polymorphic ids when UUID not configured', function () {
+        // Set UUID configuration to false
+        Config::set('wirechat.uuids', false);
+
+        // Run attachments migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000002_create_wirechat_attachments_table.php';
+        $migration->up();
+
+        // Check if attachable_id column is integer type
+        $columnType = Schema::getColumnType((new Attachment)->getTable(), 'attachable_id');
+        expect(isIntegerColumnType($columnType))->toBeTrue();
+    });
+
+    test('actions table uses integer for polymorphic ids when UUID not configured', function () {
+        // Set UUID configuration to false
+        Config::set('wirechat.uuids', false);
+
+        // Run actions migration
+        $migration = include __DIR__.'/../../database/migrations/2024_11_01_000006_create_wirechat_actions_table.php';
+        $migration->up();
+
+        // Check if actionable_id and actor_id columns are integer type
+        $actionableType = Schema::getColumnType((new Action)->getTable(), 'actionable_id');
+        $actorType = Schema::getColumnType((new Action)->getTable(), 'actor_id');
+
+        expect(isIntegerColumnType($actionableType))->toBeTrue();
+        expect(isIntegerColumnType($actorType))->toBeTrue();
+    });
+});


### PR DESCRIPTION
The `wire_attachments` and `wire_actions` table migrations were not checking the `wirechat.uuids` configuration setting, causing them to always use integer IDs even when UUID support was enabled. This created foreign key constraint issues when these tables needed to reference UUID-based conversations or messages.

- Add UUID configuration checks to attachments migration using `uuidMorphs()`
- Add UUID configuration checks to actions migration for polymorphic columns
- Add Pest tests with database-agnostic column type assertions

Targeted `0.3x`, but this issues is in `main` as well.