### PR TITLE
feat: extract conversation query into reusable method

### DIFF
--- a/src/Livewire/Chats/Chats.php
+++ b/src/Livewire/Chats/Chats.php
@@ -191,18 +191,9 @@ class Chats extends Component
         $this->reset(['page', 'canLoadMore']);
     }
 
-    /**
-     * Loads conversations based on the current page and search filters.
-     * Applies search filters and updates the conversations collection.
-     *
-     * @return void
-     */
-    protected function loadConversations()
+    protected function conversationsQuery($perPage, $offset)
     {
-        $perPage = 10;
-        $offset = ($this->page - 1) * $perPage;
-
-        $additionalConversations = $this->auth->conversations()
+        return $this->auth->conversations()
             ->with([
                 'lastMessage.sendable',
                 'group.cover' => fn ($query) => $query->select('id', 'url', 'attachable_type', 'attachable_id', 'file_path'),
@@ -214,8 +205,21 @@ class Chats extends Component
             })
             ->latest('updated_at')
             ->skip($offset)
-            ->take($perPage)
-            ->get();
+            ->take($perPage);
+    }
+
+    /**
+     * Loads conversations based on the current page and search filters.
+     * Applies search filters and updates the conversations collection.
+     *
+     * @return void
+     */
+    protected function loadConversations()
+    {
+        $perPage = 10;
+        $offset = ($this->page - 1) * $perPage;
+
+        $additionalConversations = $this->conversationsQuery($perPage, $offset)->get();
 
         // Set participants manually where needed
         $additionalConversations->each(function ($conversation) {


### PR DESCRIPTION
This PR refactors the conversation loading logic in the Chats component by extracting the query into a dedicated, reusable method.

#### 🎯 **What Changed**

- Extracted query logic from `loadConversations()` into new `conversationsQuery($perPage, $offset)` method
- Maintained exact same functionality with improved code organization
- Query can now be easily overridden in child classes for customization

#### ✨ **Benefits**

1. **Better Code Organization:** Query logic separated from pagination logic
2. **Enhanced Extensibility:** Developers can override `conversationsQuery()` to customize the query
3. **Improved Readability:** Clearer separation of concerns
4. **Easier Testing:** Query can be tested independently

#### 🔄 **Usage Example**

```php
// Override in your custom Chats component
protected function conversationsQuery($perPage, $offset)
{
    return parent::conversationsQuery($perPage, $offset)
        ->where('custom_field', 'custom_value')
        ->orWhere('another_condition', true);
}
```

#### ⚠️ **Breaking Changes**

None. All changes are backward compatible.

#### ✅ **Testing**

- [x] All existing tests pass
- [x] Manual testing of conversation loading
- [x] Verified pagination still works correctly
- [x] Confirmed no performance impact