### PR TITLE
feat: add permission checks for message send and delete actions

### DIFF
--- a/resources/views/livewire/chat/chat.blade.php
+++ b/resources/views/livewire/chat/chat.blade.php
@@ -133,7 +133,9 @@ $hasEmojiPicker= $this->panel()->hasEmojiPicker();
         {{-- ---------- --}}
         {{-- -Footer--- --}}
         {{-- ---------- --}}
+        @if ($this->canSendMessage())
         @include('wirechat::livewire.chat.partials.footer', [ 'conversation' => $conversation, 'authParticipant' => $authParticipant, 'media' => $media, 'files' => $files, 'replyMessage' => $replyMessage])
+        @endif
 
     </div>
 

--- a/resources/views/livewire/chat/partials/body.blade.php
+++ b/resources/views/livewire/chat/partials/body.blade.php
@@ -197,6 +197,7 @@
                                 @if (($isGroup && $conversation->group?->allowsMembersToSendMessages()) || $authParticipant->isAdmin())
                                 <div dusk="message_actions" @class([ 'my-auto flex  w-auto  items-center gap-2', 'order-1' => !$belongsToAuth, ])>
                                     {{-- reply button --}}
+                                    @if ($this->canSendMessage())
                                     <button wire:click="setReply('{{ encrypt($message->id) }}')"
                                         class=" invisible  group-hover:visible hover:scale-110 transition-transform">
 
@@ -207,7 +208,9 @@
                                                 d="M5.921 11.9 1.353 8.62a.72.72 0 0 1 0-1.238L5.921 4.1A.716.716 0 0 1 7 4.719V6c1.5 0 6 0 7 8-2.5-4.5-7-4-7-4v1.281c0 .56-.606.898-1.079.62z" />
                                         </svg>
                                     </button>
+                                    @endif
                                     {{-- Dropdown actions button --}}
+                                    @if ($this->canDeleteMessage() || $this->canSendMessage())
                                     <x-wirechat::dropdown class="w-40" align="{{ $belongsToAuth ? 'right' : 'left' }}"
                                         width="48">
                                         <x-slot name="trigger">
@@ -245,15 +248,18 @@
                                             @endif
 
 
+                                            @if ($this->canSendMessage())
                                             <button dusk="reply_to_message_button" wire:click="setReply('{{ encrypt($message->id) }}')"class="w-full text-start">
                                                 <x-wirechat::dropdown-link>
                                                     @lang('wirechat::chat.actions.reply.label')
                                                 </x-wirechat::dropdown-link>
                                             </button>
+                                            @endif
 
 
                                         </x-slot>
                                     </x-wirechat::dropdown>
+                                    @endif
 
                                 </div>
                                 @endif

--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -171,6 +171,9 @@ class Chat extends Component
      *  */
     public function setReply(string $id): void
     {
+        abort_unless(auth()->check(), 401);
+        abort_unless($this->canSendMessage(), 403);
+
         // descrypt
 
         $messageId = null;
@@ -333,6 +336,8 @@ class Chat extends Component
     {
 
         abort_unless(auth()->check(), 401);
+
+        abort_unless($this->canSendMessage(), 403);
 
         // rate limit
         $this->rateLimit();
@@ -532,6 +537,8 @@ class Chat extends Component
      **/
     public function deleteForEveryone(string $id): void
     {
+        abort_unless(auth()->check(), 401);
+        abort_unless($this->canDeleteMessage(), 403);
         // descrypt
         $messageId = null;
         try {
@@ -858,5 +865,15 @@ class Chat extends Component
     public function render()
     {
         return view('wirechat::livewire.chat.chat');
+    }
+
+    public function canSendMessage(): bool
+    {
+        return true;
+    }
+
+    public function canDeleteMessage(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This PR adds comprehensive permission checking for message send and delete operations, providing security controls and customization points for permission logic.

#### 🎯 **What Changed**

**Permission Methods:**
- Added `canSendMessage(): bool` method to Chat component (default: `true`)
- Added `canDeleteMessage(): bool` method to Chat component (default: `true`)
- Provides override points for custom permission logic

**Permission Enforcement:**
- Added permission checks in `setReply()` method
- Added permission check in `sendMessage()` method
- Added permission checks in `deleteForEveryone()` method
- Returns 403 Forbidden if permission denied

**Conditional UI Rendering:**
- Wrapped footer include with `@if($this->canSendMessage())`
- Wrapped reply button with `@if($this->canSendMessage())`
- Wrapped message dropdown with `@if($this->canDeleteMessage() || $this->canSendMessage())`
- Wrapped reply dropdown item with `@if($this->canSendMessage())`

#### ✨ **Benefits**

1. **Enhanced Security:** Prevents unauthorized message operations
2. **Flexible Permissions:** Easy to implement custom permission logic
3. **Better UX:** UI elements hidden when user lacks permissions
4. **Consistent Enforcement:** Permissions checked both in UI and backend methods
5. **Extensible:** Override methods for role-based, time-based, or custom permissions

#### 🔄 **Usage Examples**

```php
// Override in your custom Chat component for custom permission logic

// Example 1: Role-based permissions
public function canSendMessage(): bool
{
    return auth()->user()->hasRole('member');
}

public function canDeleteMessage(): bool
{
    return auth()->user()->hasRole('admin');
}

// Example 2: Conversation-based permissions
public function canSendMessage(): bool
{
    return $this->conversation->participants()
        ->where('participantable_id', auth()->id())
        ->where('can_send_messages', true)
        ->exists();
}

// Example 3: Time-based permissions (e.g., read-only after hours)
public function canSendMessage(): bool
{
    $hour = now()->hour;
    return $hour >= 9 && $hour < 17; // Only 9 AM - 5 PM
}

// Example 4: Subscription-based
public function canSendMessage(): bool
{
    return auth()->user()->hasActiveSubscription();
}
```

#### ⚠️ **Breaking Changes**

None. Default behavior allows all operations (returns `true`). Existing implementations continue to work without modifications.

#### 🔒 **Security Improvements**

- Server-side permission enforcement prevents unauthorized API calls
- UI elements hidden to prevent confusion and accidental attempts
- Consistent 401/403 responses for unauthorized access
- Clear separation between authentication (401) and authorization (403)

#### ✅ **Testing**

- [x] All existing tests pass
- [x] Manual testing of permission checks
- [x] Verified UI hides correctly when permissions denied
- [x] Tested 403 responses on unauthorized attempts
- [x] Confirmed default behavior (all allowed)
- [x] Tested custom permission override