### PR TITLE
fix: file upload preview on livewire v4

### DIFF
--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -206,33 +206,6 @@ class Chat extends Component
         $this->replyMessage = null;
     }
 
-    /**
-     * livewire method
-     ** This is avoid replacing temporary files on add more files
-     * We override the function in WithFileUploads Trait
-     * todo:uncomment if used this in fronend
-     */
-    public function _finishUpload($name, $tmpPath, $isMultiple)
-    {
-        $this->cleanupOldUploads();
-
-        $files = collect($tmpPath)->map(function ($i) {
-            return TemporaryUploadedFile::createFromLivewire($i);
-        })->toArray();
-        $this->dispatch('upload:finished', name: $name, tmpFilenames: collect($files)->map->getFilename()->toArray())->self();
-
-        // If the property is an array, APPEND the upload to the array.
-        $currentValue = $this->getPropertyValue($name);
-
-        if (is_array($currentValue)) {
-            $files = array_merge($currentValue, $files);
-        } else {
-            $files = $files[0];
-        }
-
-        app('livewire')->updateProperty($this, $name, $files);
-    }
-
     public function resetAttachmentErrors()
     {
 

--- a/src/Livewire/Chat/Chat.php
+++ b/src/Livewire/Chat/Chat.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
-use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
 use Livewire\WithPagination;
 use Wirechat\Wirechat\Enums\ConversationType;


### PR DESCRIPTION
This override breaks file upload preview using livewire v4.

File upload preview works perfectly without the method override.