### PR TITLE
Improve message send button in footer

### DIFF
--- a/resources/views/livewire/chat/partials/footer.blade.php
+++ b/resources/views/livewire/chat/partials/footer.blade.php
@@ -507,7 +507,6 @@
                         <div>
                             <button
                                 x-show="((body?.trim()?.length>0) ||  $wire.media.length > 0 || $wire.files.length > 0 )"
-                                x-transition.duration.300ms
                                 wire:loading.attr="disabled" wire:target="sendMessage" type="submit"
                                 id="sendMessageButton" class="bg-[var(--wc-brand-primary)] dark:bg-[var(--wc-brand-primary)] rounded-full p-2 cursor-pointer hover:text-white transition-colors ml-auto disabled:cursor-progress font-bold">
 

--- a/resources/views/livewire/chat/partials/footer.blade.php
+++ b/resources/views/livewire/chat/partials/footer.blade.php
@@ -504,22 +504,17 @@
                     <div x-cloak @class(['w-[5%] justify-end min-w-max  items-center gap-2 '])>
 
                         {{--  Submit button --}}
-                        <div class="w-7 h-7">
+                        <div>
                             <button
                                 x-show="((body?.trim()?.length>0) ||  $wire.media.length > 0 || $wire.files.length > 0 )"
-                                x-transition:enter="transition ease-out duration-100"
-                                x-transition:enter-start="opacity-0 translate-y-1"
-                                x-transition:enter-end="opacity-100 translate-y-0"  
-                                x-transition:leave="transition ease-in duration-150"
-                                x-transition:leave-start="opacity-100 translate-y-0"
-                                x-transition:leave-end="opacity-0 translate-y-1"
+                                x-transition.duration.300ms
                                 wire:loading.attr="disabled" wire:target="sendMessage" type="submit"
                                 id="sendMessageButton" class="bg-[var(--wc-brand-primary)] dark:bg-[var(--wc-brand-primary)] rounded-full p-2 cursor-pointer hover:text-white transition-colors ml-auto disabled:cursor-progress font-bold">
 
                                 <svg class="size-4.5 text-white  dark:text-gray-200" xmlns="http://www.w3.org/2000/svg"
                                     width="36" height="36" viewBox="0 0 24 24" fill="none"
                                     stroke="currentColor" stroke-width="1.9" stroke-linecap="round"
-                                    stroke-linejoin="round" class="ai ai-Send">
+                                    stroke-linejoin="round">
                                     <path
                                         d="M9.912 12H4L2.023 4.135A.662.662 0 0 1 2 3.995c-.022-.721.772-1.221 1.46-.891L22 12 3.46 20.896c-.68.327-1.464-.159-1.46-.867a.66.66 0 0 1 .033-.186L3.5 15" />
                                 </svg>


### PR DESCRIPTION
Before (button not centered):

<img width="202" height="71" alt="image" src="https://github.com/user-attachments/assets/7f113ed0-46a4-4825-9b64-388865fdc7a1" />

After (button centered):

<img width="178" height="71" alt="image" src="https://github.com/user-attachments/assets/329c59b4-4c65-4a32-9c0b-8f3ef57a023c" />


Other improvements:

* Remove duplicate "class" attribute
* Make the transition work again