### PR TITLE
docs: improve local development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ Explore the full documentation to get started and unlock Wirechat's potential:
 ## Contributing 🔧
 Thank you for considering contributing to WireChat! You can find out more on how to get started on the [**Contribution Docs**](https://wirechat.namuio.com/docs/contribution).
 
+### Local development
+
+Wirechat is a Laravel package, so contributors should work from a fork and keep each change on a focused branch:
+
+```bash
+git clone https://github.com/YOUR-USERNAME/wirechat.git
+cd wirechat
+composer install
+cp .env.example .env
+```
+
+The package uses the workbench application for local development and Orchestra Testbench for automated tests.
+
 ## Support Me ❤️
 I've invested a lot of time and resources in building and maintaining Wirechat, and your support truly makes a difference. If you find Wirechat helpful, please consider showing your appreciation by:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ cp .env.example .env
 
 The package uses the workbench application for local development and Orchestra Testbench for automated tests.
 
+Before opening a pull request, run the checks that match your change:
+
+```bash
+composer test
+php vendor/bin/pest
+php vendor/bin/pint --test
+php vendor/bin/phpstan analyse
+```
+
+Documentation-only changes do not usually require the full test suite, but code changes should include a focused test run and any relevant formatting or static analysis checks.
+
 ## Support Me ❤️
 I've invested a lot of time and resources in building and maintaining Wirechat, and your support truly makes a difference. If you find Wirechat helpful, please consider showing your appreciation by:
 


### PR DESCRIPTION
## Summary

This PR improves the README contribution guidance by adding a short local development setup section and clarifying which test commands contributors can run before opening a pull request.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] Maintenance

## What changed

- Added a concise local development flow for working from a fork.
- Documented the basic dependency installation steps.
- Listed the main test, formatting, and static analysis commands used by the package.
- Clarified that documentation-only changes usually do not require the full test suite.

## Testing

- [x] `git diff --check`
- [ ] `composer test`
- [ ] `php vendor/bin/pest`
- [ ] `php vendor/bin/pint --test`
- [ ] `php vendor/bin/phpstan analyse`
- [x] Not required because this is a documentation-only change

## Related issue

Fixes #
```

Commits:

- https://github.com/fatimaWebdev/wirechat/commit/9636f11f
- https://github.com/fatimaWebdev/wirechat/commit/0208c3c9