### PR TITLE
ux: improve empty conversation state

### DIFF
--- a/lang/en/chats.php
+++ b/lang/en/chats.php
@@ -7,7 +7,7 @@ return [
      *------------------------*/
     'labels' => [
         'heading' => 'Chats',
-        'no_conversations_yet' => 'No conversations yet',
+        'no_conversations_yet' => 'No conversations yet. Start a new chat when you are ready.',
         'you' => 'You',
         'attachment' => 'Attachment',
         'now' => 'Now',

--- a/lang/en/pages.php
+++ b/lang/en/pages.php
@@ -5,7 +5,7 @@ return [
     // chat component
     'chat' => [
         'messages' => [
-            'welcome' => 'Select a conversation to start messaging',
+            'welcome' => 'Choose a conversation to start messaging.',
 
         ],
     ],

--- a/lang/en/widgets.php
+++ b/lang/en/widgets.php
@@ -5,7 +5,7 @@ return [
     // Widget component
     'wirechat' => [
         'messages' => [
-            'welcome' => 'Select a conversation to start messaging',
+            'welcome' => 'Choose a conversation to start messaging.',
 
         ],
     ],

--- a/tests/Feature/IndexTest.php
+++ b/tests/Feature/IndexTest.php
@@ -51,7 +51,7 @@ test('it shows label "Send private photos and messages" ', function () {
     $auth = User::factory()->create();
     $response = $this->withoutExceptionHandling()->actingAs($auth)->get(testPanelProvider()->chatsRoute());
 
-    $response->assertSee('Select a conversation to start messaging');
+    $response->assertSee('Choose a conversation to start messaging.');
 
 });
 

--- a/tests/Feature/WireChatTest.php
+++ b/tests/Feature/WireChatTest.php
@@ -36,7 +36,7 @@ test('it shows label "Send private photos and messages" ', function () {
     $auth = User::factory()->create();
     $conversation = Conversation::factory()->create();
     $response = Livewire::actingAs($auth)->test(Wirechat::class);
-    $response->assertSee('Select a conversation to start messaging');
+    $response->assertSee('Choose a conversation to start messaging.');
 
 });
 


### PR DESCRIPTION
## Summary

This PR improves the English empty conversation state copy so the chat page and widget give users a clearer prompt before a conversation is selected.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] Maintenance

## What changed

- Updated the English page and widget empty-state message from "Select a conversation to start messaging" to "Choose a conversation to start messaging."
- Updated the empty chat list label to be a little more helpful when there are no conversations yet.
- Updated the focused feature test expectations for the new rendered copy.

## Testing

- [x] `php vendor/bin/pest tests/Feature/WireChatTest.php`
- [x] `git diff --check`
- [x] `composer test`
- [x] `php vendor/bin/pest`
- [ ] `php vendor/bin/pint --test`
- [ ] `php vendor/bin/phpstan analyse`

Focused test result:

```text
PASS Tests\Feature\WireChatTest
Tests: 12 passed (24 assertions)
```

## Related issue

Fixes #
```

Commits:

- https://github.com/fatimaWebdev/wirechat/commit/4d760df9
- https://github.com/fatimaWebdev/wirechat/commit/ec8aa0ce
