### PR TITLE
[codex] Fix panel provider registration in app config for 0.5x

### DIFF
--- a/src/Console/Commands/MakePanelCommand.php
+++ b/src/Console/Commands/MakePanelCommand.php
@@ -130,24 +130,38 @@ class MakePanelCommand extends Command
             $appConfigPath = config_path('app.php');
             $appConfig = file_get_contents($appConfigPath);
 
-            // Check for WirechatServiceProvider with or without full namespace
-            $anchor = Str::contains($appConfig, 'Wirechat\Wirechat\WirechatServiceProvider::class') ||
-                        Str::contains($appConfig, 'WirechatServiceProvider::class')
-                            ? 'WirechatServiceProvider::class,'
-                            : 'App\Providers\RouteServiceProvider::class,';
-
             if (! Str::contains($appConfig, $providerClass.'::class')) {
                 file_put_contents(
                     $appConfigPath,
-                    str_replace(
-                        $anchor,
-                        $anchor.PHP_EOL.'        '.$providerClass.'::class,',
-                        $appConfig
-                    )
+                    $this->addProviderToAppConfig($appConfig, $providerClass)
                 );
             }
         }
 
         $this->info("Wirechat panel [{$providerClass}] created successfully.");
+    }
+
+    protected function addProviderToAppConfig(string $appConfig, string $providerClass): string
+    {
+        $anchors = [
+            'Wirechat\\Wirechat\\WirechatServiceProvider::class,',
+            'WirechatServiceProvider::class,',
+            'App\\Providers\\RouteServiceProvider::class,',
+            'RouteServiceProvider::class,',
+            'App\\Providers\\AppServiceProvider::class,',
+            'AppServiceProvider::class,',
+        ];
+
+        foreach ($anchors as $anchor) {
+            if (Str::contains($appConfig, $anchor)) {
+                return str_replace(
+                    $anchor,
+                    $anchor.PHP_EOL.'        '.$providerClass.'::class,',
+                    $appConfig
+                );
+            }
+        }
+
+        throw new \RuntimeException('Unable to locate the providers array in config/app.php.');
     }
 }

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -16,6 +16,7 @@ use Wirechat\Wirechat\Enums\ConversationType;
 use Wirechat\Wirechat\Enums\ParticipantRole;
 use Wirechat\Wirechat\Facades\Wirechat;
 use Wirechat\Wirechat\Models\Concerns\HasDynamicIds;
+use Wirechat\Wirechat\Models\Scopes\WithoutRemovedMessages;
 use Wirechat\Wirechat\Traits\Actionable;
 use Wirechat\Wirechat\Workbench\Database\Factories\ConversationFactory;
 
@@ -26,15 +27,15 @@ use Wirechat\Wirechat\Workbench\Database\Factories\ConversationFactory;
  * @property int|null $disappearing_duration
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property \Wirechat\Wirechat\Models\Participant|null $auth_participant
- * @property \Wirechat\Wirechat\Models\Participant|null $peer_participant
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Wirechat\Wirechat\Models\Action> $actions
+ * @property Participant|null $auth_participant
+ * @property Participant|null $peer_participant
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Action> $actions
  * @property-read int|null $actions_count
  * @property-read Group|null $group
  * @property-read Message|null $lastMessage
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Message> $messages
  * @property-read int|null $messages_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Wirechat\Wirechat\Models\Participant> $participants
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Participant> $participants
  * @property-read int|null $participants_count
  *
  * @method static Builder|Conversation newModelQuery()
@@ -146,7 +147,7 @@ class Conversation extends Model
      * If participants are already loaded, it fetches from the collection.
      * Otherwise, it queries dynamically via the `participants()` relationship.
      *
-     * @param  Model|\Illuminate\Contracts\Auth\Authenticatable  $user  The user instance.
+     * @param  Model|Authenticatable  $user  The user instance.
      * @param  bool  $withoutGlobalScopes  Whether to ignore global scopes in the query.
      * @return Participant|null The corresponding participant or null if not found.
      */
@@ -246,12 +247,12 @@ class Conversation extends Model
     /**
      * Define a relationship to fetch messages for this conversation.
      */
-    public function messages(): hasMany
+    public function messages(): HasMany
     {
         return $this->hasMany(Wirechat::messageModelClass());
     }
 
-    public function lastMessage(): hasOne
+    public function lastMessage(): HasOne
     {
         return $this->hasOne(Wirechat::messageModelClass(), 'conversation_id')->latestOfMany();
     }
@@ -284,7 +285,7 @@ class Conversation extends Model
 
         $builder->whereHas('messages', function (Builder $q) use ($user, $messagesTable, $participantsTable) {
             // Remove the global scope that hides removed messages so we can apply our own logic here
-            $q->withoutGlobalScope(\Wirechat\Wirechat\Models\Scopes\WithoutRemovedMessages::class)
+            $q->withoutGlobalScope(WithoutRemovedMessages::class)
 
                 // We only want messages that are NOT deleted by the current user's participant in this conversation
                 ->whereDoesntHave('actions', function ($aq) use ($user, $messagesTable, $participantsTable) {
@@ -382,7 +383,7 @@ class Conversation extends Model
      * This method retrieves the other participant in a private conversation
      * or returns the given reference user for self conversations.
      *
-     * @param  Model|\Illuminate\Contracts\Auth\Authenticatable  $reference  The reference user/model to exclude.
+     * @param  Model|Authenticatable  $reference  The reference user/model to exclude.
      * @return Participant|null The other participant or null if not applicable.
      */
     public function peerParticipant(Model|Authenticatable $reference): ?Participant
@@ -547,7 +548,7 @@ class Conversation extends Model
     /**
      * Retrieve unread messages in this conversation for a specific user.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  Model  $user
      * @return \Illuminate\Database\Eloquent\Collection<int,Message>
      */
     public function unreadMessages(Model|Authenticatable $user): \Illuminate\Database\Eloquent\Collection
@@ -589,7 +590,7 @@ class Conversation extends Model
     /**
      * Build a correlated subquery for unread messages for a specific user.
      *
-     * @return Builder<\Wirechat\Wirechat\Models\Message>
+     * @return Builder<Message>
      */
     protected static function unreadSubqueryFor(Model|Authenticatable $user): Builder
     {
@@ -619,7 +620,7 @@ class Conversation extends Model
      * This is useful for preloading unread counts on conversation lists without
      * triggering one unread query per conversation row during rendering.
      *
-     * @return Builder<\Wirechat\Wirechat\Models\Message>
+     * @return Builder<Message>
      */
     public static function unreadCountSubqueryFor(Model|Authenticatable $user): Builder
     {
@@ -630,7 +631,7 @@ class Conversation extends Model
     /**
      * Build a correlated subquery that reports whether unread messages exist.
      *
-     * @return Builder<\Wirechat\Wirechat\Models\Message>
+     * @return Builder<Message>
      */
     public static function unreadExistsSubqueryFor(Model|Authenticatable $user): Builder
     {

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -3,12 +3,14 @@
 namespace Wirechat\Wirechat\Models;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Wirechat\Wirechat\Enums\Actions;
 use Wirechat\Wirechat\Enums\MessageType;
@@ -16,6 +18,7 @@ use Wirechat\Wirechat\Facades\Wirechat;
 use Wirechat\Wirechat\Helpers\Helper;
 use Wirechat\Wirechat\Models\Scopes\WithoutRemovedMessages;
 use Wirechat\Wirechat\Traits\Actionable;
+use Wirechat\Wirechat\Workbench\Database\Factories\MessageFactory;
 
 /**
  * @property int $id
@@ -24,14 +27,14 @@ use Wirechat\Wirechat\Traits\Actionable;
  * @property int|null $reply_id
  * @property string|null $body
  * @property MessageType $type
- * @property \Illuminate\Support\Carbon|null $kept_at filled when a message is kept from disappearing
- * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Wirechat\Wirechat\Models\Action> $actions
+ * @property Carbon|null $kept_at filled when a message is kept from disappearing
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, Action> $actions
  * @property-read int|null $actions_count
- * @property-read \Wirechat\Wirechat\Models\Attachment|null $attachment
- * @property-read \Wirechat\Wirechat\Models\Conversation|null $conversation
+ * @property-read Attachment|null $attachment
+ * @property-read Conversation|null $conversation
  * @property-read Message|null $parent
  * @property-read Message|null $reply
  * @property-read Model|\Eloquent $sendable
@@ -95,7 +98,7 @@ class Message extends Model
 
     /**
      * @deprecated Use $message->user instead via the participant relationship.
-     * @see \Wirechat\Wirechat\Models\Message::getUserAttribute()
+     * @see Message::getUserAttribute()
      * Previously, messages had a polymorphic `sendable` relationship (sendable_type/sendable_id),
      * but now messages are linked to a participant, which provides the actual user.
      * So both $message->sendable and $message->user return the participantable.
@@ -135,7 +138,7 @@ class Message extends Model
      */
     protected static function newFactory()
     {
-        return \Wirechat\Wirechat\Workbench\Database\Factories\MessageFactory::new();
+        return MessageFactory::new();
     }
 
     protected static function booted()
@@ -241,7 +244,7 @@ class Message extends Model
     }
 
     // Relationship for the parent message
-    public function parent(): belongsTo
+    public function parent(): BelongsTo
     {
         return $this->belongsTo(Wirechat::messageModelClass(), 'reply_id')->withoutGlobalScope(WithoutRemovedMessages::class)->withTrashed();
     }

--- a/tests/Unit/Commands/MakePanelCommandTest.php
+++ b/tests/Unit/Commands/MakePanelCommandTest.php
@@ -77,6 +77,31 @@ it('overwrites existing file when user confirms', function () {
     expect(File::get($this->filePath))->toContain("class {$this->className}");
 });
 
+it('registers providers in config app files that import provider classes', function () {
+    $appConfig = <<<'PHP'
+<?php
+
+use App\Providers\AppServiceProvider;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Support\ServiceProvider;
+
+return [
+    'providers' => ServiceProvider::defaultProviders()->merge([
+        AppServiceProvider::class,
+        RouteServiceProvider::class,
+    ])->toArray(),
+];
+PHP;
+
+    $method = new ReflectionMethod(MakePanelCommand::class, 'addProviderToAppConfig');
+    $method->setAccessible(true);
+
+    $registeredConfig = $method->invoke(new MakePanelCommand, $appConfig, $this->providerClass);
+
+    expect($registeredConfig)
+        ->toContain("RouteServiceProvider::class,\n        {$this->providerClass}::class,");
+});
+
 it('shows validation error for invalid ID', function () {
     $this->artisan('make:wirechat-panel')
         ->expectsQuestion('What is the panel ID?', '1234bad')


### PR DESCRIPTION
## Summary

Backports the panel provider registration fix to the `0.5x` branch so `make:wirechat-panel` can correctly update apps whose `config/app.php` imports provider classes and lists short provider names like `RouteServiceProvider::class`.

## Root cause

The generator only recognized fully-qualified provider anchors such as `App\Providers\RouteServiceProvider::class`. Apps using imported provider classes could see the panel provider file created successfully while the provider was never inserted into `config/app.php`, leaving the panel routes unregistered.

## Changes

- Teach `MakePanelCommand` to recognize fully-qualified and imported provider anchors.
- Add a regression test for imported-provider `config/app.php` files.
- Fix 0.5x relation return type casing that blocked the repo pre-push PHPStan gate.

## Validation

- `vendor/bin/pest tests/Unit/Commands/MakePanelCommandTest.php`
- `vendor/bin/pint src/Console/Commands/MakePanelCommand.php tests/Unit/Commands/MakePanelCommandTest.php src/Models/Conversation.php src/Models/Message.php --test`
- `vendor/bin/phpstan analyse`
- Pre-push PHPStan hook passed during `git push`