### PR TITLE
[codex] Center widget empty state

### DIFF
--- a/resources/views/livewire/widgets/wire-chat.blade.php
+++ b/resources/views/livewire/widgets/wire-chat.blade.php
@@ -242,7 +242,11 @@
             {{-- In widget mode, the drawer lives at the shell level so it survives chat component refreshes. --}}
             <livewire:wirechat.chat.drawer wire:key="widget-chat-drawer" />
 
-            <div  x-show="!show && !chatIsOpen " class="m-auto  justify-center flex gap-3 flex-col  items-center ">
+            <div
+                x-show="!show && !chatIsOpen"
+                dusk="widget-empty-state"
+                class="absolute inset-0 flex items-center justify-center px-4 text-center"
+            >
 
                 <h4 class="font-medium p-2 px-3 rounded-full font-semibold bg-[var(--wc-light-secondary)] dark:bg-[var(--wc-dark-secondary)] dark:text-white dark:font-normal">@lang('wirechat::widgets.wirechat.messages.welcome')</h4>
 

--- a/tests/Feature/WireChatTest.php
+++ b/tests/Feature/WireChatTest.php
@@ -98,6 +98,15 @@ test('it applies ui classes and styles to the widget shell only', function () {
         ->and($styleMatches[0])->toHaveCount(1);
 });
 
+test('it centers the widget empty state across the chat panel', function () {
+    $html = file_get_contents(dirname(__DIR__, 2).'/resources/views/livewire/widgets/wire-chat.blade.php');
+
+    expect($html)
+        ->toContain('dusk="widget-empty-state"')
+        ->toContain('absolute inset-0 flex items-center justify-center px-4 text-center')
+        ->toContain("@lang('wirechat::widgets.wirechat.messages.welcome')");
+});
+
 test('wirechat styles uses the dark palette and supports extending zinc shades', function () {
     $customDark = [
         900 => 'oklch(0.18 0.01 285.9)',


### PR DESCRIPTION
## Summary
- Centers the widget empty state across the full chat panel instead of relying on `m-auto`.
- Keeps the existing welcome text and pill styling unchanged.
- Adds a focused regression assertion for the widget empty-state wrapper.

## Checks
- `vendor/bin/pest tests/Feature/WireChatTest.php --filter='centers the widget empty state'`
- Pre-push `vendor/bin/phpstan analyse --configuration=phpstan.neon`

Note: the full local `WireChatTest.php` run on this `origin/0.6x` base still hits the existing `Unable to detect application namespace` render failure outside this change; the new focused assertion passes.