### PR TITLE
[codex] Drop Laravel 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,17 @@
         }
     },
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "livewire/livewire": "^3.7|^4.0",
-        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.0|^0.3.5"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "orchestra/testbench": "^8.24|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.34|^3.0.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^2.4|^3.0.0|^4.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0.0|^4.0",
         "christophrumpel/missing-livewire-assertions": "^2.8|^3.0|^4.0",
         "laravel/pint": "^1.18",
         "larastan/larastan": "^2.0|^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "985ae780a20914928787b09f75f3b1c7",
+    "content-hash": "8e4490c522fc97c49d4d73faa6470802",
     "packages": [
         {
             "name": "brick/math",
@@ -10209,7 +10209,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1|^8.2|^8.3|^8.4"
+        "php": "^8.2|^8.3|^8.4|^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary

Removes Laravel 10 from the supported Composer constraint for the free Wirechat package.

## Changes

- Require Laravel `^11.0|^12.0|^13.0` instead of `^10.0|^11.0|^12.0|^13.0`.
- Raise the PHP support floor to PHP 8.2, matching Laravel 11+.
- Remove Laravel 10-era Testbench and Pest constraints from dev requirements.
- Refresh the Composer lock content hash.

## Validation

- `composer update --lock --no-install --no-interaction`
- `composer validate --strict`
- `git diff --check`
- Push hook PHPStan: no errors

Note: `composer update --lock` reported existing security advisories in the free package dependency set; this PR does not change package versions.