### PR TITLE
Fix group invite approval flow

### DIFF
--- a/resources/views/livewire/chat/group/info.blade.php
+++ b/resources/views/livewire/chat/group/info.blade.php
@@ -7,6 +7,7 @@
         $isGroup = $conversation?->isGroup();
         $group = $conversation?->group;
         $canManageInvites = $authIsAdminInGroup && $this->panel()->hasGroupInvitations();
+        $canManageJoinRequests = $canManageInvites && $group?->requiresInviteApproval();
         $canUseInviteLinks = ($authIsAdminInGroup || $group?->allowsMembersToInviteOthersViaLink()) && $this->panel()->hasGroupInvitations();
     @endphp
 
@@ -241,7 +242,7 @@
             </x-wirechat::actions.open-chat-drawer>
         @endif
 
-        @if ($canManageInvites)
+        @if ($canManageJoinRequests)
             <x-wirechat::actions.open-chat-drawer component="wirechat.chat.group.join.requests"
                 conversation="{{ $conversation?->id }}" widget="{{ $this->isWidget() }}" :panel="$this->panel">
                 <button class="cursor-pointer w-full py-5 px-8 hover:bg-[var(--wc-light-secondary)] dark:hover:bg-[var(--wc-dark-secondary)] focus:outline-hidden transition flex items-center justify-between gap-3">

--- a/resources/views/livewire/chat/group/links/send.blade.php
+++ b/resources/views/livewire/chat/group/links/send.blade.php
@@ -30,9 +30,9 @@
         <section class="overflow-x-hidden my-2">
             <ul style="-ms-overflow-style: none; scrollbar-width: none;" class="flex w-full overflow-x-auto gap-3">
                 @foreach ($selectedMembers as $member)
-                    <li class="flex items-center text-nowrap min-w-fit px-2 py-1 text-sm font-medium text-gray-800 bg-[var(--wc-light-secondary)] rounded-sm dark:bg-[var(--wc-dark-secondary)] dark:text-gray-300" wire:key="selected-invite-member-{{ $member->id }}">
+                    <li class="flex items-center text-nowrap min-w-fit px-2 py-1 text-sm font-medium text-gray-800 bg-[var(--wc-light-secondary)] rounded-sm dark:bg-[var(--wc-dark-secondary)] dark:text-gray-300" wire:key="selected-invite-member-{{ md5($member->getMorphClass()) }}-{{ $member->getKey() }}">
                         {{ $member->wirechat_name }}
-                        <button type="button" wire:click="toggleMember('{{ $member->id }}', {{ json_encode(get_class($member)) }})"
+                        <button type="button" wire:click="toggleMember('{{ $member->getKey() }}', {{ json_encode($member->getMorphClass()) }})"
                             class="flex items-center p-1 ms-2 text-sm text-gray-400 bg-transparent rounded-xs hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-gray-300">
                             <svg class="w-2 h-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
                                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
@@ -49,7 +49,7 @@
             @if ($users)
                 <ul class="overflow-auto flex flex-col">
                     @foreach ($users as $key => $user)
-                        <li wire:key="invite-users-{{ $key }}" class="flex cursor-pointer group gap-2 items-center p-2">
+                        <li wire:key="invite-users-{{ md5((string) $user['type']) }}-{{ $user['id'] }}" class="flex cursor-pointer group gap-2 items-center p-2">
                             <label wire:click="toggleMember('{{ $user['id'] }}', {{ json_encode($user['type']) }})" class="flex cursor-pointer gap-2 items-center w-full">
                                 <x-wirechat::avatar src="{{ $user['wirechat_avatar_url'] }}" class="w-10 h-10" />
 
@@ -58,7 +58,7 @@
                                 </div>
 
                                 <div class="ml-auto">
-                                    @if ($selectedMembers->contains(fn($member) => $member->id == $user['id'] && get_class($member) == $user['type']))
+                                    @if ($selectedMembers->contains(fn($member) => (string) $member->getKey() === (string) $user['id'] && $member->getMorphClass() === $user['type']))
                                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-square w-6 h-6 text-green-500" viewBox="0 0 16 16">
                                             <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z" />
                                             <path d="m10.97 4.97-3.992 4.99-1.75-1.75a.75.75 0 1 0-1.06 1.06l2.325 2.324a.75.75 0 0 0 1.08-.022l4.525-5.656a.75.75 0 1 0-1.128-.944" />

--- a/resources/views/livewire/chat/group/members/add.blade.php
+++ b/resources/views/livewire/chat/group/members/add.blade.php
@@ -80,10 +80,10 @@
 
                 @foreach ($selectedMembers as $key => $member)
                     <li class="flex items-center text-nowrap min-w-fit px-2 py-1 text-sm font-medium text-gray-800 bg-[var(--wc-light-secondary)] rounded-sm dark:bg-[var(--wc-dark-secondary)] dark:text-gray-300"
-                        wire:key="selected-member-{{ $member->id }}">
+                        wire:key="selected-member-{{ md5($member->getMorphClass()) }}-{{ $member->getKey() }}">
                         {{ $member->wirechat_name }}
                         <button type="button"
-                            wire:click="toggleMember('{{ $member->id }}',{{ json_encode(get_class($member)) }})"
+                            wire:click="toggleMember('{{ $member->getKey() }}',{{ json_encode($member->getMorphClass()) }})"
                             class="flex items-center p-1 ms-2 text-sm text-gray-400 bg-transparent rounded-xs hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-gray-300"
                             aria-label="Remove">
                             <svg class="w-2 h-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +119,7 @@
                         $isBanned = (bool) ($user['isBanned'] ?? false);
                     @endphp
                     <li
-                        wire:key="users-{{$key}}"
+                        wire:key="users-{{ md5((string) $user['type']) }}-{{ $user['id'] }}"
                         @class([
                             'flex group gap-2 items-center p-2',
                             'cursor-not-allowed opacity-60' => $isBanned,
@@ -151,11 +151,11 @@
                                 @elseif ($isBanned)
                                 {{ __('wirechat::chat.group.join.lobby.labels.join_blocked') }}
                                 @endif
-                             </span>
+                            </span>
                            </div>
 
                             <div class="ml-auto">
-                                @if ($selectedMembers->contains(fn($member) => $member->id == $user['id'] && get_class($member) == $user['type']) || $isAlreadyAParticipant)
+                                @if ($selectedMembers->contains(fn($member) => (string) $member->getKey() === (string) $user['id'] && $member->getMorphClass() === $user['type']) || $isAlreadyAParticipant)
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                         fill="currentColor"
                                         class="bi bi-plus-square-fill w-6 h-6 text-green-500"

--- a/resources/views/livewire/chat/partials/header.blade.php
+++ b/resources/views/livewire/chat/partials/header.blade.php
@@ -2,7 +2,7 @@
 
 @php
     $group = $conversation->group;
-    $pendingJoinRequestsCount = $conversation->isGroup() && $authParticipant?->isAdmin() && $this->panel()->hasGroupInvitations() ? $conversation->group?->pendingJoinRequests()->count(): 0;
+    $pendingJoinRequestsCount = $conversation->isGroup() && $authParticipant?->isAdmin() && $this->panel()->hasGroupInvitations() && $group?->requiresInviteApproval() ? $group->pendingJoinRequests()->count(): 0;
     $hasMessageRequests = $this->panel()->hasMessageRequests();
     $hasActiveMessageRequest = $hasMessageRequests && $conversation->isPrivate() && $conversation->hasActiveMessageRequest();
 @endphp

--- a/resources/views/livewire/new/group.blade.php
+++ b/resources/views/livewire/new/group.blade.php
@@ -167,10 +167,10 @@
 
                             @foreach ($selectedMembers as $key => $member)
                                 <li class="flex items-center text-nowrap min-w-fit px-2 py-1 text-sm font-medium text-gray-800  bg-[var(--wc-light-secondary)] dark:bg-[var(--wc-dark-secondary)] rounded-sm  dark:text-gray-300"
-                                    wire:key="selected-member-{{ $member->id }}">
+                                    wire:key="selected-member-{{ md5($member->getMorphClass()) }}-{{ $member->getKey() }}">
                                     {{ $member->wirechat_name }}
                                     <button type="button"
-                                        wire:click="toggleMember('{{ $member->id }}',{{ json_encode(get_class($member)) }})"
+                                        wire:click="toggleMember('{{ $member->getKey() }}',{{ json_encode($member->getMorphClass()) }})"
                                         class="flex items-center p-1 ms-2 text-sm text-gray-400 bg-transparent rounded-xs hover:bg-[var(--wc-light-secondary)] dark:hover:bg-[var(--wc-dark-secondary)]  hover:text-gray-900  dark:hover:text-gray-300"
                                         aria-label="Remove">
                                         <svg class="w-2 h-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
@@ -201,7 +201,7 @@
                     @if (count($users)!=0)
                         <ul class="overflow-auto flex flex-col">
                             @foreach ($users as $key => $user)
-                                <li class="flex cursor-pointer group gap-2 items-center p-2">
+                                <li wire:key="new-group-users-{{ md5((string) $user['type']) }}-{{ $user['id'] }}" class="flex cursor-pointer group gap-2 items-center p-2">
 
                                     <label
                                         wire:click="toggleMember('{{ $user['id'] }}',{{ json_encode($user['type']) }})"
@@ -212,7 +212,7 @@
                                             {{ $user['wirechat_name'] }}</p>
 
                                         <div class="ml-auto">
-                                            @if ($selectedMembers->contains(fn($member) => $member->id == $user['id'] && $member->getMorphClass() == $user['type']))
+                                            @if ($selectedMembers->contains(fn($member) => (string) $member->getKey() === (string) $user['id'] && $member->getMorphClass() === $user['type']))
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                                     fill="currentColor"
                                                     class="bi bi-plus-square-fill w-6 h-6 text-green-500"

--- a/src/Http/Controllers/InviteController.php
+++ b/src/Http/Controllers/InviteController.php
@@ -44,6 +44,7 @@ class InviteController extends Controller
         $isMember = false;
         $hasPendingJoinRequest = false;
         $joinBlocked = false;
+        $requiresApproval = false;
 
         if ($auth !== null) {
             $isMember = $auth->belongsToConversation($conversation);
@@ -54,7 +55,8 @@ class InviteController extends Controller
                 return redirect()->to(Wirechat::currentPanel()->chatRoute($conversation->id));
             }
 
-            $hasPendingJoinRequest = $group->hasPendingJoinRequest($auth);
+            $requiresApproval = $group->requiresInviteApproval();
+            $hasPendingJoinRequest = $requiresApproval && $group->hasPendingJoinRequest($auth);
             $joinBlocked = $group->inviteJoinBlockedFor($auth);
         }
 
@@ -67,6 +69,7 @@ class InviteController extends Controller
             'isMember' => $isMember,
             'hasPendingJoinRequest' => $hasPendingJoinRequest,
             'joinBlocked' => $joinBlocked,
+            'requiresApproval' => $requiresApproval,
         ]);
     }
 

--- a/src/Livewire/Chat/Group/Info.php
+++ b/src/Livewire/Chat/Group/Info.php
@@ -265,7 +265,9 @@ class Info extends ModalComponent
 
         $this->totalParticipants = $this->conversation->participants_count;
         $this->group = $this->conversation->group;
-        $this->pendingJoinRequestsCount = (int) ($this->group?->pendingJoinRequests()->count() ?? 0);
+        $this->pendingJoinRequestsCount = $this->group->requiresInviteApproval()
+            ? (int) $this->group->pendingJoinRequests()->count()
+            : 0;
         $this->setDefaultValues();
     }
 
@@ -273,8 +275,8 @@ class Info extends ModalComponent
     {
 
         $participant = $this->conversation->participant(auth()->user());
-        $this->pendingJoinRequestsCount = $this->conversation->isGroup() && $participant?->isAdmin() && $this->panel()->hasGroupInvitations()
-            ? (int) ($this->group?->pendingJoinRequests()->count() ?? 0)
+        $this->pendingJoinRequestsCount = $this->conversation->isGroup() && $participant?->isAdmin() && $this->panel()->hasGroupInvitations() && $this->group->requiresInviteApproval()
+            ? (int) $this->group->pendingJoinRequests()->count()
             : 0;
 
         //  dd($this->isWidget(),$participant);

--- a/src/Livewire/Chat/Group/Join/Lobby.php
+++ b/src/Livewire/Chat/Group/Join/Lobby.php
@@ -84,9 +84,9 @@ class Lobby extends ModalComponent
         $auth = auth()->user();
 
         $this->isMember = $auth->belongsToConversation($this->conversation);
-        $this->hasPendingJoinRequest = ! $this->isMember && $this->group->hasPendingJoinRequest($auth);
         $this->joinBlocked = ! $this->isMember && $this->group->inviteJoinBlockedFor($auth);
         $this->requiresApproval = ! $this->isMember && $this->group->requiresInviteApproval();
+        $this->hasPendingJoinRequest = $this->requiresApproval && $this->group->hasPendingJoinRequest($auth);
     }
 
     public function proceed()
@@ -101,6 +101,9 @@ class Lobby extends ModalComponent
             return null;
         }
 
+        $this->group = $this->group->fresh();
+        $this->syncState();
+
         if ($this->isMember) {
             return $this->redirectAfterJoin();
         }
@@ -111,7 +114,7 @@ class Lobby extends ModalComponent
             return null;
         }
 
-        if ($this->hasPendingJoinRequest) {
+        if ($this->requiresApproval && $this->hasPendingJoinRequest) {
             $this->dispatch('wirechat-toast', type: 'info', message: __('wirechat::chat.group.join.lobby.messages.pending_request'));
 
             return null;
@@ -126,8 +129,17 @@ class Lobby extends ModalComponent
             return null;
         }
 
+        $hadPendingJoinRequest = $this->group->hasPendingJoinRequest($auth);
+
+        if ($hadPendingJoinRequest) {
+            $this->group->requestToJoin($auth, $this->invite);
+        }
+
         $this->conversation->join($auth);
-        $this->invite?->markUsed();
+
+        if (! $hadPendingJoinRequest) {
+            $this->invite?->markUsed();
+        }
 
         return $this->redirectAfterJoin();
     }

--- a/src/Livewire/Chat/Group/Links/Links.php
+++ b/src/Livewire/Chat/Group/Links/Links.php
@@ -99,16 +99,17 @@ class Links extends ModalComponent
         $authParticipant = $this->conversation->participant(auth()->user());
         $canManageInvites = (bool) $authParticipant?->isAdmin();
         $primaryInvite = $this->invite->fresh(['createdBy']);
+        $requiresApproval = $this->group->requiresInviteApproval();
 
         return view('wirechat::livewire.chat.group.links.links', [
             'primaryInvite' => $primaryInvite,
             'primaryInviteUrl' => $primaryInvite->url($this->panel()),
             'canManageInvites' => $canManageInvites,
             'canResetLink' => $canManageInvites,
-            'canManageJoinRequests' => $canManageInvites,
+            'canManageJoinRequests' => $canManageInvites && $requiresApproval,
             'canEditGroupAccess' => (bool) $authParticipant?->isOwner(),
-            'pendingJoinRequestsCount' => $this->group->pendingJoinRequests()->count(),
-            'requiresAdminApproval' => (bool) $this->group->admins_must_approve_new_members,
+            'pendingJoinRequestsCount' => $requiresApproval ? $this->group->pendingJoinRequests()->count() : 0,
+            'requiresAdminApproval' => $requiresApproval,
         ]);
     }
 

--- a/src/Livewire/Chat/Group/Links/Send.php
+++ b/src/Livewire/Chat/Group/Links/Send.php
@@ -60,7 +60,7 @@ class Send extends ModalComponent
                 $model = $resource->resource;
 
                 return [
-                    'id' => $model->id,
+                    'id' => $model->getKey(),
                     'type' => $model->getMorphClass(),
                     'wirechat_name' => $model->wirechat_name,
                     'wirechat_avatar_url' => $model->wirechat_avatar_url,
@@ -73,6 +73,14 @@ class Send extends ModalComponent
     {
         $this->authorizeSendAccess();
 
+        if ($this->selectedMembers->contains(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)) {
+            $this->selectedMembers = $this->selectedMembers
+                ->reject(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)
+                ->values();
+
+            return;
+        }
+
         $model = $this->resolvePanelSearchResult($id, $class);
 
         if (! $model) {
@@ -80,14 +88,6 @@ class Send extends ModalComponent
         }
 
         abort_unless($this->canReceiveInviteLink($model, shouldAbort: true), 403);
-
-        if ($this->selectedMembers->contains(fn ($member) => $member->getKey() == $model->getKey() && get_class($member) == get_class($model))) {
-            $this->selectedMembers = $this->selectedMembers->reject(function ($member) use ($id, $class) {
-                return $member->getKey() == $id && $member->getMorphClass() == $class;
-            })->values();
-
-            return;
-        }
 
         $this->selectedMembers->push($model);
     }

--- a/src/Livewire/Chat/Group/Members/AddMembers.php
+++ b/src/Livewire/Chat/Group/Members/AddMembers.php
@@ -92,40 +92,42 @@ class AddMembers extends ModalComponent
     {
         $this->authorizeAddMembersAccess();
 
+        if ($this->selectedMembers->contains(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)) {
+            $this->selectedMembers = $this->selectedMembers
+                ->reject(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)
+                ->values();
+            $this->newTotalCount = count($this->selectedMembers) + $this->exitingMembersCount;
+
+            return;
+        }
+
         $model = $this->resolveGroupAddableSearchResult($id, $class);
 
         if ($model) {
             abort_if($model->belongsToConversation($this->conversation), 403, $model->wirechat_name.' Is already a member');
 
-            if ($this->selectedMembers->contains(fn ($member) => $member->getKey() == $model->getKey() && get_class($member) == get_class($model))) {
-                $this->selectedMembers = $this->selectedMembers->reject(function ($member) use ($id, $class) {
-                    return $member->getKey() == $id && $member->getMorphClass() == $class;
-                });
-            } else {
-                if ($this->newTotalCount >= $this->panel()->getMaxGroupMembers()) {
-                    return $this->dispatch('show-member-limit-error');
-                }
-
-                $participant = $this->conversation->participant($model, withoutGlobalScopes: true);
-
-                if ($participant?->isBannedByAdmin()) {
-                    $this->dispatch(
-                        'wirechat-toast',
-                        type: 'warning',
-                        message: 'Cannot add '.$model->wirechat_name.' because they were banned from the group by an Admin.'
-                    );
-
-                    return;
-                }
-                abort_if($participant?->hasExited(), 403, 'Cannot add '.$model->wirechat_name.' because they left the group');
-
-                if ($participant?->isRemovedByAdmin()) {
-                    abort_unless($this->authParticipant?->isAdmin(), 403, 'Cannot add '.$model->wirechat_name.' because they were removed from the group by an Admin.');
-                }
-
-                $this->selectedMembers->push($model);
+            if ($this->newTotalCount >= $this->panel()->getMaxGroupMembers()) {
+                return $this->dispatch('show-member-limit-error');
             }
 
+            $participant = $this->conversation->participant($model, withoutGlobalScopes: true);
+
+            if ($participant?->isBannedByAdmin()) {
+                $this->dispatch(
+                    'wirechat-toast',
+                    type: 'warning',
+                    message: 'Cannot add '.$model->wirechat_name.' because they were banned from the group by an Admin.'
+                );
+
+                return;
+            }
+            abort_if($participant?->hasExited(), 403, 'Cannot add '.$model->wirechat_name.' because they left the group');
+
+            if ($participant?->isRemovedByAdmin()) {
+                abort_unless($this->authParticipant?->isAdmin(), 403, 'Cannot add '.$model->wirechat_name.' because they were removed from the group by an Admin.');
+            }
+
+            $this->selectedMembers->push($model);
             $this->newTotalCount = count($this->selectedMembers) + $this->exitingMembersCount;
         }
     }

--- a/src/Livewire/New/Group.php
+++ b/src/Livewire/New/Group.php
@@ -96,7 +96,7 @@ class Group extends ModalComponent
             $model = $this->resolveGroupAddableSearchResult($id, $class);
 
             if ($model) {
-                if (! $this->selectedMembers->contains($model)) {
+                if (! $this->selectedMembers->contains(fn ($member) => (string) $member->getKey() === (string) $model->getKey() && $member->getMorphClass() === $model->getMorphClass())) {
                     $this->selectedMembers->push($model);
                 }
             }
@@ -110,33 +110,32 @@ class Group extends ModalComponent
     public function removeMember($id, string $class)
     {
         // Filter out the member with the specified ID and class
-        $this->selectedMembers = $this->selectedMembers->reject(function ($member) use ($id, $class) {
-            return $member->getKey() == $id && $member->getMorphClass() == $class;
-        });
+        $this->selectedMembers = $this->selectedMembers
+            ->reject(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)
+            ->values();
     }
 
     public function toggleMember($id, string $class)
     {
 
+        if ($this->selectedMembers->contains(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)) {
+            $this->selectedMembers = $this->selectedMembers
+                ->reject(fn ($member) => (string) $member->getKey() === (string) $id && $member->getMorphClass() === $class)
+                ->values();
+
+            return;
+        }
+
         $model = $this->resolveGroupAddableSearchResult($id, $class);
 
         if ($model) {
-            if ($this->selectedMembers->contains(fn ($member) => $member->getKey() == $model->getKey() && get_class($member) == get_class($model))) {
-                // Remove member if they are already selected
-                $this->selectedMembers = $this->selectedMembers->reject(function ($member) use ($id, $class) {
-                    return $member->getKey() == $id && $member->getMorphClass() == $class;
-                });
-            } else {
-
-                // validte members count
-                if (count($this->selectedMembers) >= $this->panel()->getMaxGroupMembers()) {
-                    return $this->dispatch('show-member-limit-error');
-                }
-
-                // Add member if they are not selected
-                $this->selectedMembers->push($model);
-
+            // validte members count
+            if (count($this->selectedMembers) >= $this->panel()->getMaxGroupMembers()) {
+                return $this->dispatch('show-member-limit-error');
             }
+
+            // Add member if they are not selected
+            $this->selectedMembers->push($model);
 
         }
     }

--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -205,7 +205,7 @@ class Group extends Model
 
     public function requiresInviteApproval(): bool
     {
-        return $this->isPrivateAccess() || (bool) $this->admins_must_approve_new_members;
+        return (bool) $this->admins_must_approve_new_members;
     }
 
     public function inviteJoinBlockedFor(Model|Authenticatable $user): bool

--- a/tests/Feature/Chat/Group/InfoTest.php
+++ b/tests/Feature/Chat/Group/InfoTest.php
@@ -1121,6 +1121,7 @@ describe('Exiting Chat', function () {
         $dismissedRequester = User::factory()->create();
 
         $conversation = $auth->createGroup(name: 'My Group', description: 'This is a good group');
+        $conversation->group->forceFill(['admins_must_approve_new_members' => true])->save();
 
         foreach (range(1, 12) as $index) {
             $conversation->group->requestToJoin(User::factory()->create(['name' => "Requester {$index}"]));

--- a/tests/Feature/Chat/Group/InviteFeatureTest.php
+++ b/tests/Feature/Chat/Group/InviteFeatureTest.php
@@ -553,6 +553,7 @@ it('shows invite management actions only to admins in group info', function () {
 
     $conversation = $owner->createGroup('Test');
     $conversation->group->allow_members_to_add_others = true;
+    $conversation->group->admins_must_approve_new_members = true;
     $conversation->group->save();
 
     $adminParticipant = $conversation->addParticipant($admin);
@@ -1265,6 +1266,8 @@ it('creates a join request from the in-app invite modal when approval is require
     $receiver = User::factory()->create();
 
     $conversation = $owner->createGroup('Test');
+    $conversation->group->forceFill(['admins_must_approve_new_members' => true])->save();
+
     $invite = $conversation->group->inviteLinks()->create([
         'panel_id' => testPanelProvider()->getId(),
         'created_by_id' => $owner->getKey(),
@@ -1285,6 +1288,58 @@ it('creates a join request from the in-app invite modal when approval is require
     expect($receiver->belongsToConversation($conversation))->toBeFalse()
         ->and($conversation->group->hasPendingJoinRequest($receiver))->toBeTrue()
         ->and(in_array($invite->usages, [null, 0], true))->toBeTrue();
+});
+
+it('lets invite users join immediately when admin approval is turned off after a pending request exists', function () {
+    $owner = User::factory()->create();
+    $receiver = User::factory()->create();
+
+    $conversation = $owner->createGroup('Test');
+    $conversation->group->forceFill(['admins_must_approve_new_members' => true])->save();
+
+    $invite = $conversation->group->inviteLinks()->create([
+        'panel_id' => testPanelProvider()->getId(),
+        'created_by_id' => $owner->getKey(),
+        'created_by_type' => $owner->getMorphClass(),
+        'token' => Invite::generateToken(),
+        'is_primary' => true,
+    ]);
+
+    Livewire::actingAs($receiver)
+        ->test(Lobby::class, ['token' => $invite->token, 'panel' => testPanelProvider()->getId()])
+        ->call('proceed')
+        ->assertNoRedirect();
+
+    expect($receiver->belongsToConversation($conversation))->toBeFalse()
+        ->and($conversation->group->hasPendingJoinRequest($receiver))->toBeTrue();
+
+    $conversation->group->forceFill(['admins_must_approve_new_members' => false])->save();
+
+    Livewire::actingAs($owner)
+        ->test(GroupInfo::class, ['conversation' => $conversation, 'panel' => testPanelProvider()->getId()])
+        ->assertSet('pendingJoinRequestsCount', 0)
+        ->assertDontSee(__('wirechat::chat.group.join.requests.heading.label'));
+
+    Livewire::actingAs($owner)
+        ->test(Links::class, ['conversation' => $conversation, 'panel' => testPanelProvider()->getId()])
+        ->assertSee(__('wirechat::chat.group.invite_link.labels.group_access_open'))
+        ->assertDontSee(__('wirechat::chat.group.invite_link.labels.join_requests'));
+
+    Livewire::actingAs($receiver)
+        ->test(Lobby::class, ['token' => $invite->token, 'panel' => testPanelProvider()->getId()])
+        ->assertSet('requiresApproval', false)
+        ->assertSet('hasPendingJoinRequest', false)
+        ->assertSee(__('wirechat::chat.group.join.lobby.labels.open_access'))
+        ->assertSee(__('wirechat::chat.group.join.lobby.actions.join_group.label'))
+        ->call('proceed')
+        ->assertRedirect(testPanelProvider()->chatRoute($conversation->id));
+
+    $invite->refresh();
+
+    expect($receiver->belongsToConversation($conversation))->toBeTrue()
+        ->and($conversation->group->pendingJoinRequests()->count())->toBe(0)
+        ->and($conversation->group->joinRequests()->where('status', JoinRequestStatus::ACCEPTED)->count())->toBe(1)
+        ->and($invite->usages)->toBe(1);
 });
 
 it('allows admin-removed users to request join from lobby when approval is required', function () {
@@ -1610,6 +1665,7 @@ it('shows the join request banner only to group admins', function () {
     $requester = User::factory()->create();
 
     $conversation = $owner->createGroup('Test');
+    $conversation->group->forceFill(['admins_must_approve_new_members' => true])->save();
     $conversation->addParticipant($member);
     $conversation->group->requestToJoin($requester);
 
@@ -1627,6 +1683,7 @@ it('shows the join request banner only to group admins', function () {
 it('pluralizes the join request banner summary for admins', function () {
     $owner = User::factory()->create();
     $conversation = $owner->createGroup('Test');
+    $conversation->group->forceFill(['admins_must_approve_new_members' => true])->save();
 
     $conversation->group->requestToJoin(User::factory()->create());
     $conversation->group->requestToJoin(User::factory()->create());

--- a/tests/Feature/Chat/Group/InviteFeatureTest.php
+++ b/tests/Feature/Chat/Group/InviteFeatureTest.php
@@ -395,6 +395,31 @@ it('can send an invite link via chat', function () {
         ->and($privateConversation->messages()->latest('id')->first()->body)->toContain($invite->url(testPanelProvider()));
 });
 
+it('removes selected invite recipients after the search query changes', function () {
+    $owner = User::factory()->create(['name' => 'Owner']);
+    $receiver = User::factory()->create(['name' => 'Receiver One']);
+    User::factory()->create(['name' => 'Receiver Two']);
+
+    $conversation = $owner->createGroup('Test');
+    $invite = $conversation->group->inviteLinks()->create([
+        'panel_id' => testPanelProvider()->getId(),
+        'created_by_id' => $owner->getKey(),
+        'created_by_type' => $owner->getMorphClass(),
+        'token' => Invite::generateToken(),
+        'is_primary' => true,
+    ]);
+
+    Livewire::actingAs($owner)
+        ->test(Send::class, ['conversation' => $conversation, 'invite' => $invite, 'panel' => testPanelProvider()->getId()])
+        ->set('search', 'Receiver One')
+        ->call('toggleMember', $receiver->getKey(), $receiver->getMorphClass())
+        ->assertSee('Receiver One')
+        ->set('search', 'Receiver Two')
+        ->call('toggleMember', $receiver->getKey(), $receiver->getMorphClass())
+        ->assertSet('selectedMembers', collect())
+        ->assertDontSee('Receiver One');
+});
+
 it('ignores tampered send invite selections outside the current panel search results', function () {
     $owner = User::factory()->create(['name' => 'Owner']);
     $receiver = User::factory()->create(['name' => 'Receiver']);

--- a/tests/Feature/Info/AddMembersTest.php
+++ b/tests/Feature/Info/AddMembersTest.php
@@ -266,6 +266,24 @@ describe('actions test', function () {
             ->assertDontSee('Micheal');
     });
 
+    test('toggleMember() removes selected members after the search query changes', function () {
+        $auth = User::factory()->create();
+        $conversation = $auth->createGroup('My Group');
+        $user = User::factory()->create(['name' => 'Micheal']);
+        User::factory()->create(['name' => 'Jessica']);
+
+        Livewire::actingAs($auth)->test(AddMembers::class, ['conversation' => $conversation, 'panel' => testPanelProvider()->getId()])
+            ->set('search', 'Micheal')
+            ->call('toggleMember', $user->id, $user->getMorphClass())
+            ->assertSee('Micheal')
+            ->assertSet('newTotalCount', 2)
+            ->set('search', 'Jessica')
+            ->call('toggleMember', $user->id, $user->getMorphClass())
+            ->assertSet('selectedMembers', collect())
+            ->assertSet('newTotalCount', 1)
+            ->assertDontSee('Micheal');
+    });
+
     test('existing member cannot be added to selectedMembers it aborts 403', function () {
         $auth = User::factory()->create();
         $conversation = $auth->createGroup('My Group');

--- a/tests/Feature/NewGroupTest.php
+++ b/tests/Feature/NewGroupTest.php
@@ -260,6 +260,21 @@ describe('Add members page', function () {
             ->assertDontSee('Micheal');
     });
 
+    test('calling toggleMember() removes selected members after the search query changes', function () {
+        $auth = ModelsUser::factory()->create();
+        $user = ModelsUser::factory()->create(['name' => 'Micheal']);
+        ModelsUser::factory()->create(['name' => 'Jessica']);
+
+        Livewire::actingAs($auth)->test(NewGroup::class)
+            ->set('search', 'Micheal')
+            ->call('toggleMember', $user->id, $user->getMorphClass())
+            ->assertSee('Micheal')
+            ->set('search', 'Jessica')
+            ->call('toggleMember', $user->id, $user->getMorphClass())
+            ->assertSet('selectedMembers', collect())
+            ->assertDontSee('Micheal');
+    });
+
     test('show error if member limit is exceeded', function () {
 
         testPanelProvider()->maxGroupMembers(2);


### PR DESCRIPTION
## Summary
- make group invite approval follow the `admins_must_approve_new_members` toggle
- prevent stale pending join requests from blocking open invite joins
- hide join-request review counts and entry points when approval is off
- prevent double invite usage when an open join accepts an existing pending request

## Tests
- `vendor/bin/pest tests/Feature/Chat/Group/InviteFeatureTest.php tests/Feature/Chat/Group/InfoTest.php`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`